### PR TITLE
central inv config. no hardcoded info in scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 venv
+
+*/config.py

--- a/scripts/netmiko_learning.py
+++ b/scripts/netmiko_learning.py
@@ -1,7 +1,7 @@
 #! /usr/bin/env python
 
 from netmiko import ConnectHandler
-
+from config import inv
 """
 Netmiko is a fork of Paramiko and simplifies the
 channel management when connecting to a network device
@@ -9,8 +9,15 @@ channel management when connecting to a network device
 Example from "Mastering Python Networking" by Eric Chou
 """
 
+dev = inv.get("iosv-1")
+
 # Define the device to connect to
-ios_v1 = {"device_type": "ios", "host": "172.16.1.20", "username": "cisco", "password": "cisco"}
+ios_v1 = {
+    "device_type": dev.get("type"),
+    "host": dev.get("host"),
+    "username": dev.get("user"),
+    "password": dev.get("pass")
+    }
 
 # Connect to the device
 net_connect = ConnectHandler(**ios_v1)

--- a/scripts/nx-netconf_learning.py
+++ b/scripts/nx-netconf_learning.py
@@ -1,7 +1,7 @@
 #! /usr/bin/env python
 
 from ncclient import manager
-
+from config import inv
 """
 NX-API is turned off by default on Cisco Nexus devices. Here
 are steps to enable it via CLI:
@@ -16,13 +16,15 @@ ncclient is a Python library for NETCONF clients.
 Example from "Mastering Python Networking" by Eric Chou
 """
 
+dev = inv.get("nexus")
+
 conn = manager.connect(
-    host="172.16.1.90",
-    port=22,
-    username="cisco",
-    password="cisco",
+    host=dev.get("host"),
+    port=dev.get("port"),
+    username=dev.get("user"),
+    password=dev.get("pass"),
     hostkey_verify=False,  # Bypasses the known_hosts requirement
-    device_params={"name": "nexus"},  # Specifies the type of device
+    device_params={"name": dev.get("type")},  # Specifies the type of device
     look_for_keys=False  # Disables the private-public key auth
 )
 

--- a/scripts/paramiko_learning.py
+++ b/scripts/paramiko_learning.py
@@ -1,6 +1,7 @@
 #! /usr/bin/env python
 
 import paramiko
+from config import inv
 
 """
 Paramiko is a low-level SSHv2 library. Hard dependency on
@@ -11,13 +12,15 @@ underlying connection protocol for Ansible network modules
 Example from "Mastering Python Networking" by Eric Chou
 """
 
+dev = inv.get("iosv-1")
+
 connection = paramiko.SSHClient()
 
 # Automatically adds SSH keys
 connection.set_missing_host_key_policy(paramiko.AutoAddPolicy)
 
 # Connect to the device
-connection.connect("172.16.1.20", username="cisco", password="cisco", look_for_keys=False, allow_agent=False)
+connection.connect(dev.get("host"), username=dev.get("user"), password=dev.get("pass"), look_for_keys=False, allow_agent=False)
 
 # Create connections
 new_connection = connection.invoke_shell()

--- a/scripts/pexpect_learning.py
+++ b/scripts/pexpect_learning.py
@@ -1,6 +1,8 @@
 #! /usr/bin/env python3
 
 import pexpect
+from config import inv
+
 
 """
 Pexpect spawns child processes, controls them with parent process,
@@ -10,14 +12,16 @@ and responds to expected patterns in output. Similar to TCL
 Example from "Mastering Python Networking" by Eric Chou
 """
 
+dev = inv.get("iosv-1")
+
 # Connect to network device
-child = pexpect.spawn("telnet 172.16.1.20")
+child = pexpect.spawn(f"telnet {dev.get('host')}")
 
 # Logging into the device
 child.expect("Username")
-child.sendline("cisco")
+child.sendline(dev.get("user"))
 child.expect("Password")
-child.sendline("cisco")
+child.sendline(dev.get("pass"))
 
 # Expecting prompt
 child.expect("iosv-1#")

--- a/scripts/sample_config.py
+++ b/scripts/sample_config.py
@@ -1,0 +1,23 @@
+# Copy this file to config.py, and update config.py with real inventory data
+inv = {
+    "iosv-1": {
+        "type": "ios",
+        "host": "172.16.1.20",
+        "port": 22,
+        "user": "cisco",
+        "pass": "cisco"
+    },
+    "192.168.7.151": {
+        "type": "iosxe",
+        "host": "192.168.7.151",
+        "user": "cisco",
+        "pass": "cisco",
+        "enable_pass": "cisco"
+    },
+    "nexus": {
+        "type": "nexus",
+        "host": "172.16.1.90",
+        "user": "cisco",
+        "pass": "cisco"
+    }
+}

--- a/scripts/scrapli_learning.py
+++ b/scripts/scrapli_learning.py
@@ -1,11 +1,15 @@
 from scrapli.driver.core import IOSXEDriver
 from pprint import pprint
+from config import inv
+
+dev = inv.get("192.168.7.151")
+
 
 MY_DEVICE = {
-    "host": "192.168.7.151",
-    "auth_username": "cisco",
-    "auth_password": "cisco",
-    "auth_secondary": "cisco", # Enable password (if used)
+    "host": dev.get("host"),
+    "auth_username": dev.get("user"),
+    "auth_password": dev.get("pass"),
+    "auth_secondary": dev.get("enable_pass"), # Enable password (if used)
     "auth_strict_key": False,
     "ssh_config_file": "config" # Need to include for older cipher suites (vIOS 15.x)
 }


### PR DESCRIPTION
This PR will all you to specify all device info in a config.py file, so there will be no hardcoding of device information in the scripts themselves. This should make it easier for others to re-use your scripts in their study efforts.